### PR TITLE
Fix blog post description field

### DIFF
--- a/blog/welcome/index.qmd
+++ b/blog/welcome/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Welcome To My Blog"
 author: "Tristan O'Malley"
-Description: "Hello, this is the description to my blog"
+description: "Hello, this is the description to my blog"
 date: "2022-10-22"
 categories: [news]
 ---


### PR DESCRIPTION
## Summary
- fix YAML field name for the welcome blog post

## Testing
- `quarto --version`
- `quarto render blog/welcome/index.qmd`


------
https://chatgpt.com/codex/tasks/task_e_6840a2e99ba4832bad0fcb694a046e74